### PR TITLE
feat: add client scoped subscription block and several missing properties in servicebus subscriptions, queues and rules

### DIFF
--- a/examples/subscription-rules/topics.tf
+++ b/examples/subscription-rules/topics.tf
@@ -10,6 +10,9 @@ locals {
         all-events = {
           max_delivery_count = 10
           lock_duration      = "PT5M"
+          client_scoped_subscription = {
+            is_client_scoped_subscription_shareable = true
+          }
           rules = {
             all_messages = {
               filter_type = "SqlFilter"


### PR DESCRIPTION
## Description

This PR adds client scoped subscription block and several missing properties in servicebus subscriptions, queues and rules

```
=== NAME  TestApplyAllParallel
    deploy_test.go:165: All modules applied and destroyed successfully.
--- PASS: TestApplyAllParallel (0.00s)
    --- PASS: TestApplyAllParallel/default (187.44s)
    --- PASS: TestApplyAllParallel/subscription-rules (201.83s)
    --- PASS: TestApplyAllParallel/authorization-rules (741.08s)
    --- PASS: TestApplyAllParallel/topics (789.32s)
    --- PASS: TestApplyAllParallel/queues (863.26s)
PASS
ok      github.com/cloudnationhq/terraform-azure-sb     863.665s
```

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)